### PR TITLE
Fix admin actions

### DIFF
--- a/altchat-v2/app.py
+++ b/altchat-v2/app.py
@@ -15,8 +15,9 @@ from database import (
     get_all_user_phones, get_role, ban_user, temp_ban_user, unban_user,
     reset_user_password, rename_user, set_user_color, toggle_mod_status,
     promote_to_admin, log_admin_action, get_user_history,
-    set_user_color, get_user_color_from_db,
+    set_user_color, get_user_color_from_db, set_user_role,
     update_user_status, get_user_status, set_user_dnd, get_user_dnd, init_altchat_tables,
+    is_user_banned,
 )
 from random import choice
 
@@ -31,25 +32,14 @@ socketio = SocketIO(
     transports=["websocket", "polling"]  # ✅ wichtig!
 )
 
-
 logging.basicConfig(level=logging.DEBUG)
-
-app = Flask(__name__)
-init_altchat_tables()
-app.secret_key = os.urandom(24)
-
-socketio = SocketIO(
-    app,
-    async_mode='eventlet',
-    cors_allowed_origins="*",
-    max_http_buffer_size=1000000  # Diese Zeile wurde ergänzt!
-)
 
 
 ADMIN_PASSWORD = "80024042"
 online_users = set()
-last_seen = {}  
+last_seen = {}
 USER_COLORS = {}
+user_sids = {}
 COLOR_PALETTE = ["#00ff00", "#66ff66", "#00cc00", "#33ff33", "#FF69B4", "#3333FF", "#FF69B4", "#FF0000"]
 chat_history = {"main": []}
 MAX_PN_MESSAGES = 50
@@ -98,12 +88,6 @@ def load_private_messages(room, limit=50):
     rows = c.fetchall()
     conn.close()
     return rows[::-1]
-
-def get_user_color(username):
-    if username not in USER_COLORS:
-        USER_COLORS[username] = choice(COLOR_PALETTE)
-    return USER_COLORS[username]
-
 
 def to_alt_language(text):
     mapping = {
@@ -165,9 +149,11 @@ def login():
         username = request.form.get('username', '').strip()
         password = request.form.get('password', '')
         if verify_user(username, password):
+            if is_user_banned(username):
+                flash('User ist gebannt!')
+                return redirect(url_for('login'))
             session['username'] = username
             update_user_status(username, "online")
-            set_user_dnd(username, False)
             return redirect(url_for('mychats'))
         else:
             flash('Login fehlgeschlagen!')
@@ -225,8 +211,6 @@ def chat():
 
     username = session['username']
     update_user_status(username, "online")
-    if not get_user_dnd(username):  
-        set_user_dnd(username, False)
 
     target = request.args.get("user")
 
@@ -237,7 +221,8 @@ def chat():
             messages.append({
                 "timestamp": timestamp,
                 "username": uname,
-                "message": message
+                "message": message,
+                "color": get_user_color_from_db(uname)
             })
 
         return render_template('chat.html',
@@ -276,7 +261,8 @@ def chat():
         messages.append({
             "timestamp": timestamp,
             "username": uname,
-            "message": message
+            "message": message,
+            "color": get_user_color_from_db(uname)
         })
 
     if not target or target == "main":
@@ -345,6 +331,120 @@ def user_history(username):
         return jsonify({'error': 'Forbidden'}), 403
     history = get_user_history(username)
     return jsonify({'history': history})
+
+@app.route('/temp_ban/<username>', methods=['POST'])
+def route_temp_ban(username):
+    if 'username' not in session:
+        return jsonify({'status': 'unauthorized'}), 403
+    if get_role(session['username']) not in ['admin', 'mod']:
+        return jsonify({'status': 'forbidden'}), 403
+    temp_ban_user(username, 86400)
+    log_admin_action(session['username'], 'temp ban', username)
+    return jsonify({'status': 'success'})
+
+@app.route('/unban/<username>', methods=['POST'])
+def route_unban(username):
+    if 'username' not in session:
+        return jsonify({'status': 'unauthorized'}), 403
+    if get_role(session['username']) not in ['admin', 'mod']:
+        return jsonify({'status': 'forbidden'}), 403
+    unban_user(username)
+    log_admin_action(session['username'], 'unban', username)
+    return jsonify({'status': 'success'})
+
+@app.route('/perm_ban/<username>', methods=['POST'])
+def route_perm_ban(username):
+    if 'username' not in session:
+        return jsonify({'status': 'unauthorized'}), 403
+    if get_role(session['username']) not in ['admin', 'mod']:
+        return jsonify({'status': 'forbidden'}), 403
+    ban_user(username)
+    log_admin_action(session['username'], 'perm ban', username)
+    return jsonify({'status': 'success'})
+
+@app.route('/kick/<username>', methods=['POST'])
+def route_kick(username):
+    if 'username' not in session:
+        return jsonify({'status': 'unauthorized'}), 403
+    if get_role(session['username']) not in ['admin', 'mod']:
+        return jsonify({'status': 'forbidden'}), 403
+    online_users.discard(username)
+    update_user_status(username, 'offline')
+    sid = user_sids.pop(username, None)
+    socketio.emit('user_update', list(online_users), broadcast=True)
+    if sid:
+        socketio.emit('force_logout', to=sid)
+    log_admin_action(session['username'], 'kick', username)
+    return jsonify({'status': 'success'})
+
+@app.route('/reset_password/<username>', methods=['POST'])
+def route_reset_password(username):
+    if 'username' not in session:
+        return jsonify({'status': 'unauthorized'}), 403
+    if get_role(session['username']) not in ['admin', 'mod']:
+        return jsonify({'status': 'forbidden'}), 403
+    new_pw = request.get_json().get('password')
+    if not new_pw:
+        return jsonify({'status': 'invalid'}), 400
+    reset_user_password(username, new_pw)
+    log_admin_action(session['username'], 'reset password', username)
+    return jsonify({'status': 'success'})
+
+@app.route('/rename_user/<username>', methods=['POST'])
+def route_rename_user(username):
+    if 'username' not in session:
+        return jsonify({'status': 'unauthorized'}), 403
+    if get_role(session['username']) not in ['admin', 'mod']:
+        return jsonify({'status': 'forbidden'}), 403
+    new_name = request.get_json().get('new_username')
+    if not new_name:
+        return jsonify({'status': 'invalid'}), 400
+    rename_user(username, new_name)
+    log_admin_action(session['username'], f'rename to {new_name}', username)
+    return jsonify({'status': 'success'})
+
+@app.route('/set_color/<username>', methods=['POST'])
+def route_set_color(username):
+    if 'username' not in session:
+        return jsonify({'status': 'unauthorized'}), 403
+    if get_role(session['username']) not in ['admin', 'mod']:
+        return jsonify({'status': 'forbidden'}), 403
+    color = request.get_json().get('color')
+    if not color:
+        return jsonify({'status': 'invalid'}), 400
+    set_user_color(username, color)
+    log_admin_action(session['username'], f'set color to {color}', username)
+    return jsonify({'status': 'success'})
+
+@app.route('/promote_mod/<username>', methods=['POST'])
+def route_promote_mod(username):
+    if 'username' not in session:
+        return jsonify({'status': 'unauthorized'}), 403
+    if get_role(session['username']) != 'admin':
+        return jsonify({'status': 'forbidden'}), 403
+    toggle_mod_status(username)
+    log_admin_action(session['username'], 'toggle mod', username)
+    return jsonify({'status': 'success'})
+
+@app.route('/promote_admin/<username>', methods=['POST'])
+def route_promote_admin(username):
+    if 'username' not in session:
+        return jsonify({'status': 'unauthorized'}), 403
+    if get_role(session['username']) != 'admin':
+        return jsonify({'status': 'forbidden'}), 403
+    promote_to_admin(username)
+    log_admin_action(session['username'], 'promote admin', username)
+    return jsonify({'status': 'success'})
+
+@app.route('/set_role_user/<username>', methods=['POST'])
+def route_set_role_user(username):
+    if 'username' not in session:
+        return jsonify({'status': 'unauthorized'}), 403
+    if get_role(session['username']) != 'admin':
+        return jsonify({'status': 'forbidden'}), 403
+    set_user_role(username, 'user')
+    log_admin_action(session['username'], 'set role user', username)
+    return jsonify({'status': 'success'})
 
 @app.route('/set_status/<status>')
 def set_status(status):
@@ -535,11 +635,16 @@ def handle_join(data):
         return
 
     join_room(room)
+    user_sids[username] = request.sid
     print(f"[SOCKET] {username} joined room: {room}")
 
-    if room == 'main_room':
+    if username not in online_users:
         online_users.add(username)
         emit('user_update', list(online_users), broadcast=True)
+    else:
+        emit('user_update', list(online_users), to=request.sid)
+
+    if room == 'main_room':
         emit('message', {
             'username': 'System',
             'message': f'{username} ist beigetreten.',
@@ -552,16 +657,22 @@ def handle_join(data):
 @socketio.on('leave')
 def handle_leave(data):
     username = session.get('username')
+    room = data.get('room')
     if username:
         online_users.discard(username)
-        leave_room('main_room')
+        user_sids.pop(username, None)
         emit('user_update', list(online_users), broadcast=True)
-        emit('message', {
-            'username': 'System',
-            'message': f'{username} hat den Chat verlassen.',
-            'color': '#999999',
-            'timestamp': datetime.now().strftime('%d.%m.%Y %H:%M:%S')
-        }, room='main_room')
+
+        if room:
+            leave_room(room)
+
+        if room == 'main_room':
+            emit('message', {
+                'username': 'System',
+                'message': f'{username} hat den Chat verlassen.',
+                'color': '#999999',
+                'timestamp': datetime.now().strftime('%d.%m.%Y %H:%M:%S')
+            }, room='main_room')
 
 def monitor_inactive_users():
     while True:
@@ -588,8 +699,9 @@ def handle_keep_alive():
 @socketio.on('typing')
 def handle_typing(data):
     username = session.get('username')
+    room = data.get('room', 'main_room')
     if username:
-        emit('typing', {'username': username}, room='main', include_self=False)
+        emit('typing', {'username': username}, room=room, include_self=False)
 
 @socketio.on('message')
 def handle_message(data):
@@ -639,21 +751,14 @@ def handle_message(data):
         if len(chat_history[room]) > 50:
             chat_history[room] = chat_history[room][-50:]
 
-        user1, user2 = room.split("___")
-        conn = sqlite3.connect("chat.db")
-        c = conn.cursor()
-        c.execute("""
-            INSERT INTO private_messages (sender, receiver, message, timestamp)
-            VALUES (?, ?, ?, ?)
-        """, (username, user2 if username == user1 else user1, formatted_message, timestamp))
-        conn.commit()
-        conn.close()
+        save_private_message(room, username, formatted_message)
 
     emit('message', {
         "username": username,
         "message": formatted_message,
         "timestamp": timestamp,
-        "room": room
+        "room": room,
+        "color": get_user_color_from_db(username)
     }, room=room)
 
     all_users = get_all_usernames()

--- a/altchat-v2/database.py
+++ b/altchat-v2/database.py
@@ -1,11 +1,12 @@
 import sqlite3
 from werkzeug.security import generate_password_hash, check_password_hash
-import os
+from datetime import datetime, timedelta
 
 DB_PATH = 'users.db'
 
+
 def init_db():
-    conn = sqlite3.connect(chat.db)
+    conn = sqlite3.connect(DB_PATH)
     c = conn.cursor()
     c.execute('''
         CREATE TABLE IF NOT EXISTS users (
@@ -21,6 +22,7 @@ def init_db():
     ''')
     conn.commit()
     conn.close()
+
 
 def init_altchat_tables():
     conn = sqlite3.connect(DB_PATH)
@@ -43,8 +45,26 @@ def init_altchat_tables():
         )
     ''')
 
+    c.execute('''
+        CREATE TABLE IF NOT EXISTS bans (
+            username TEXT PRIMARY KEY,
+            until TEXT
+        )
+    ''')
+
+    c.execute('''
+        CREATE TABLE IF NOT EXISTS admin_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            actor TEXT,
+            action TEXT,
+            target TEXT,
+            timestamp TEXT
+        )
+    ''')
+
     conn.commit()
     conn.close()
+
 
 def add_user(username, password, phone):
     try:
@@ -54,13 +74,14 @@ def add_user(username, password, phone):
                   (username, password, phone))
         conn.commit()
         return True
-    except:
+    except Exception:
         return False
     finally:
         conn.close()
 
+
 def verify_user(username, password):
-    conn = sqlite3.connect('users.db')
+    conn = sqlite3.connect(DB_PATH)
     c = conn.cursor()
     c.execute('SELECT password FROM users WHERE username = ?', (username,))
     row = c.fetchone()
@@ -68,6 +89,7 @@ def verify_user(username, password):
     if row:
         return row[0] == password
     return False
+
 
 def user_exists(username):
     conn = sqlite3.connect(DB_PATH)
@@ -77,6 +99,7 @@ def user_exists(username):
     conn.close()
     return exists
 
+
 def get_role(username):
     conn = sqlite3.connect(DB_PATH)
     c = conn.cursor()
@@ -84,6 +107,7 @@ def get_role(username):
     row = c.fetchone()
     conn.close()
     return row[0] if row else 'user'
+
 
 def get_phone_by_username(username):
     conn = sqlite3.connect(DB_PATH)
@@ -93,6 +117,7 @@ def get_phone_by_username(username):
     conn.close()
     return row[0] if row else None
 
+
 def get_all_usernames():
     conn = sqlite3.connect(DB_PATH)
     c = conn.cursor()
@@ -101,16 +126,20 @@ def get_all_usernames():
     conn.close()
     return [row[0] for row in rows]
 
+
 def get_user_by_username(username):
     conn = sqlite3.connect(DB_PATH)
     c = conn.cursor()
     c.execute('SELECT * FROM users WHERE username = ?', (username,))
     row = c.fetchone()
-    conn.close()
     if row:
-        keys = [description[0] for description in c.description]
-        return dict(zip(keys, row))
-    return None
+        keys = [d[0] for d in c.description]
+        user = dict(zip(keys, row))
+    else:
+        user = None
+    conn.close()
+    return user
+
 
 def get_all_users_with_roles():
     conn = sqlite3.connect(DB_PATH)
@@ -118,19 +147,56 @@ def get_all_users_with_roles():
     c.execute('SELECT username, role FROM users')
     rows = c.fetchall()
     conn.close()
-    return rows
+    return [{'username': row[0], 'role': row[1] or 'user'} for row in rows]
+
 
 def ban_user(username):
-    # Dummy
-    pass
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute('INSERT OR REPLACE INTO bans (username, until) VALUES (?, ?)',
+              (username, 'perm'))
+    conn.commit()
+    conn.close()
+
 
 def temp_ban_user(username, duration):
-    # Dummy
-    pass
+    until = (datetime.now() + timedelta(seconds=duration)).isoformat()
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute('INSERT OR REPLACE INTO bans (username, until) VALUES (?, ?)',
+              (username, until))
+    conn.commit()
+    conn.close()
+
 
 def unban_user(username):
-    # Dummy
-    pass
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute('DELETE FROM bans WHERE username = ?', (username,))
+    conn.commit()
+    conn.close()
+
+
+def is_user_banned(username):
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute('SELECT until FROM bans WHERE username = ?', (username,))
+    row = c.fetchone()
+    conn.close()
+    if not row:
+        return False
+    until = row[0]
+    if until == 'perm':
+        return True
+    try:
+        expiry = datetime.fromisoformat(until)
+    except ValueError:
+        return False
+    if expiry <= datetime.now():
+        unban_user(username)
+        return False
+    return True
+
 
 def reset_user_password(username, new_password):
     conn = sqlite3.connect(DB_PATH)
@@ -140,12 +206,14 @@ def reset_user_password(username, new_password):
     conn.commit()
     conn.close()
 
+
 def rename_user(old_username, new_username):
     conn = sqlite3.connect(DB_PATH)
     c = conn.cursor()
     c.execute('UPDATE users SET username = ? WHERE username = ?', (new_username, old_username))
     conn.commit()
     conn.close()
+
 
 def set_user_color(username, color):
     conn = sqlite3.connect(DB_PATH)
@@ -154,23 +222,34 @@ def set_user_color(username, color):
     conn.commit()
     conn.close()
 
+
 def get_user_color_from_db(username):
     conn = sqlite3.connect(DB_PATH)
     c = conn.cursor()
     c.execute('SELECT color FROM users WHERE username = ?', (username,))
     row = c.fetchone()
     conn.close()
-    return row[0] if row else None
+    return row[0] if row and row[0] else None
+
 
 def log_admin_action(actor, action, target):
-    # Optional Logging
-    pass
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute('INSERT INTO admin_log (actor, action, target, timestamp) VALUES (?, ?, ?, ?)',
+              (actor, action, target, datetime.now().isoformat()))
+    conn.commit()
+    conn.close()
 
-def get_user_history(username):
-    # Dummy
-    return []
 
-# ✅ NEU: STATUS + DND Handling
+def get_user_history(username, limit=20):
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute('SELECT timestamp, action FROM admin_log WHERE target = ? ORDER BY id DESC LIMIT ?',
+              (username, limit))
+    rows = c.fetchall()
+    conn.close()
+    return [{'timestamp': r[0], 'action': r[1]} for r in rows]
+
 
 def update_user_status(username, status):
     conn = sqlite3.connect(DB_PATH)
@@ -178,6 +257,7 @@ def update_user_status(username, status):
     c.execute('UPDATE users SET status = ? WHERE username = ?', (status, username))
     conn.commit()
     conn.close()
+
 
 def get_user_status(username):
     conn = sqlite3.connect(DB_PATH)
@@ -187,12 +267,14 @@ def get_user_status(username):
     conn.close()
     return row[0] if row else 'offline'
 
+
 def set_user_dnd(username, state: bool):
     conn = sqlite3.connect(DB_PATH)
     c = conn.cursor()
     c.execute('UPDATE users SET dnd = ? WHERE username = ?', (1 if state else 0, username))
     conn.commit()
     conn.close()
+
 
 def get_user_dnd(username):
     conn = sqlite3.connect(DB_PATH)
@@ -202,77 +284,73 @@ def get_user_dnd(username):
     conn.close()
     return bool(row[0]) if row else False
 
+
 def delete_user(username):
-    conn = sqlite3.connect('users.db')
+    conn = sqlite3.connect(DB_PATH)
     c = conn.cursor()
     try:
-        c.execute("DELETE FROM users WHERE username = ?", (username,))
+        c.execute('DELETE FROM users WHERE username = ?', (username,))
         conn.commit()
         return True
-    except Exception as e:
-        print(f"[DB] Fehler beim Löschen von '{username}': {e}")
+    except Exception:
         return False
     finally:
         conn.close()
 
+
 def get_all_user_phones():
-    conn = sqlite3.connect('users.db')
+    conn = sqlite3.connect(DB_PATH)
     c = conn.cursor()
     try:
-        c.execute("SELECT phone FROM users")
+        c.execute('SELECT phone FROM users')
         result = c.fetchall()
-        return [row[0] for row in result if row[0]]  
-    except Exception as e:
-        print(f"[DB] Fehler beim Abrufen der Telefonnummern: {e}")
+        return [row[0] for row in result if row[0]]
+    except Exception:
         return []
     finally:
         conn.close()
 
+
 def toggle_mod_status(username):
-    conn = sqlite3.connect('users.db')
+    conn = sqlite3.connect(DB_PATH)
     c = conn.cursor()
     try:
-        # Aktuelle Rolle holen
-        c.execute("SELECT role FROM users WHERE username = ?", (username,))
+        c.execute('SELECT role FROM users WHERE username = ?', (username,))
         row = c.fetchone()
         if not row:
-            print(f"[DB] User '{username}' nicht gefunden.")
             return False
-
         current_role = row[0]
-
         if current_role == 'admin':
-            print(f"[DB] Admin-Rolle darf nicht geändert werden.")
             return False
-
         new_role = 'mod' if current_role == 'user' else 'user'
-        c.execute("UPDATE users SET role = ? WHERE username = ?", (new_role, username))
+        c.execute('UPDATE users SET role = ? WHERE username = ?', (new_role, username))
         conn.commit()
         return True
-    except Exception as e:
-        print(f"[DB] Fehler bei toggle_mod_status für '{username}': {e}")
+    except Exception:
         return False
     finally:
         conn.close()
+
 
 def promote_to_admin(username):
-    conn = sqlite3.connect('users.db')
+    conn = sqlite3.connect(DB_PATH)
     c = conn.cursor()
     try:
-        # Sicherstellen, dass der User existiert
-        c.execute("SELECT role FROM users WHERE username = ?", (username,))
-        row = c.fetchone()
-        if not row:
-            print(f"[DB] Benutzer '{username}' nicht gefunden.")
+        c.execute('SELECT role FROM users WHERE username = ?', (username,))
+        if not c.fetchone():
             return False
-
-        # Rolle aktualisieren
         c.execute("UPDATE users SET role = 'admin' WHERE username = ?", (username,))
         conn.commit()
-        print(f"[DB] Benutzer '{username}' wurde zu Admin befördert.")
         return True
-    except Exception as e:
-        print(f"[DB] Fehler bei promote_to_admin für '{username}': {e}")
+    except Exception:
         return False
     finally:
         conn.close()
+
+
+def set_user_role(username, role):
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute('UPDATE users SET role = ? WHERE username = ?', (role, username))
+    conn.commit()
+    conn.close()

--- a/altchat-v2/templates/admin.html
+++ b/altchat-v2/templates/admin.html
@@ -130,6 +130,7 @@
                 <button onclick="permBan('{{ user.username }}')">Ban</button>
                 <button onclick="promoteMod('{{ user.username }}')">Mod</button>
                 <button onclick="promoteAdmin('{{ user.username }}')">Admin</button>
+                <button onclick="setUserRole('{{ user.username }}')">User</button>
               {% endif %}
             {% endif %}
           {% else %}
@@ -150,11 +151,6 @@
     </div>
   </div>
 
-<script>
-    from database import (
-    init_db, delete_user, get_all_user_phones, ban_user, temp_ban_user, unban_user, reset_user_password, rename_user, toggle_mod_status, promote_to_admin,
-    )
-</script>
 
   <script>
     function closeModal() {
@@ -219,6 +215,7 @@
         sendAction('promote_admin', username);
       }
     }
+    function setUserRole(username) { sendAction('set_role_user', username); }
 
     window.onclick = function(event) {
       const modal = document.getElementById('historyModal');

--- a/altchat-v2/templates/chat.html
+++ b/altchat-v2/templates/chat.html
@@ -304,11 +304,7 @@
         {% for msg in messages %}
           {% set user = msg.username %}
           {% set message = msg.message %}
-          {% set color =
-            '#FF69B4' if user == 'Aleajoleen07' else
-            'red' if user == 'MrX' else
-            '#FF69B4' if user == 'ich_mag_tomaten' else
-            '#30D5C8' %}
+          {% set color = msg.color or get_user_color(user) or '#30D5C8' %}
           <div class="chat-message">
             <strong class="username" style="color: {{ color | default('#30D5C8') }}">{{ user }}</strong>
             <small>[{{ msg.timestamp }}]</small>: 
@@ -383,11 +379,11 @@
       toggleMessageDisplay(decodeToggle.checked);
     });
 
-    socket.emit('join', { username });
+    socket.emit('join', { username, room });
 
     socket.on('message', (data) => {
       const userColor =
-        data.username === "MrX" ? "red" 
+        data.username === "MrX" ? "red"
         : data.username === "Aleajoleen07" ? "pink"
         : data.color || "#FF69B4";
 
@@ -403,6 +399,10 @@
       `;
       chatBox.appendChild(msgElement);
       chatBox.scrollTop = chatBox.scrollHeight;
+    });
+
+    socket.on('force_logout', () => {
+      window.location.href = '/logout';
     });
 
     socket.on('user_update', users => {
@@ -425,7 +425,7 @@
     messageForm.addEventListener('submit', e => {
       e.preventDefault();
       if (!input.value.trim()) return;
-      socket.emit('message', { message: input.value });
+      socket.emit('message', { message: input.value, room });
       input.value = '';
     });
 
@@ -434,7 +434,7 @@
     });
 
     window.addEventListener('beforeunload', () => {
-      socket.emit('leave', { username });
+      socket.emit('leave', { username, room });
     });
 
     const hamburgerBtn = document.getElementById('hamburgerBtn');


### PR DESCRIPTION
## Summary
- create bans table and implement ban helpers
- block banned users at login
- add HTTP routes for admin actions
- clean admin panel script
- implement user role demotion, color handling and force-logout
- persist DND setting and show online users reliably

## Testing
- `python3 -m py_compile altchat-v2/app.py altchat-v2/database.py`

------
https://chatgpt.com/codex/tasks/task_e_687e68d39a84832dae6306fb56e2f0a3